### PR TITLE
WIP: Basic error handling / logging

### DIFF
--- a/Datahub.Web/Pages/Error.cshtml.cs
+++ b/Datahub.Web/Pages/Error.cshtml.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Diagnostics;
+
 
 namespace Datahub.Web.Pages
 {
@@ -15,9 +18,22 @@ namespace Datahub.Web.Pages
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
+        private ILogger<ErrorModel> Logger { get; set; }
+
+        public ErrorModel(ILogger<ErrorModel> logger)
+        {
+            Logger = logger;
+        }
+
         public void OnGet()
         {
-            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+            IExceptionHandlerPathFeature exceptionFeature = HttpContext.Features.Get<IExceptionHandlerPathFeature>();
+
+            if (exceptionFeature != null) {
+                Exception ex = exceptionFeature.Error;
+                RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+                Logger.LogError("{RequestId}: {Message}", RequestId, ex.ToString());
+            } 
         }
     }
 }


### PR DESCRIPTION
Its a bit of a weird one under the hood here, have got it to log out as an error properly and to pull out the request ID and error message correctly, should log out into the docker logs when deployed. Not entirely happy with this though hence WIP.

Essentially the /Error page does get the error in a roundabout way, but you need to pull it out, you can do other stuff with it, but we are just interested in pulling it out I think.