### PR TITLE
Ensure download links are HTTPS

### DIFF
--- a/Datahub.Web/Pages/Asset.cshtml
+++ b/Datahub.Web/Pages/Asset.cshtml
@@ -130,7 +130,7 @@
                                     <div class="cell small-11">
                                         <div class="highlightable">
                                             <span>
-                                                <a href="@AssetHelpers.EnsureHttpsLink((d.Http.Url))"
+                                                <a href="@AssetHelpers.EnsureHttpsLinksForDataDotJncc((d.Http.Url))"
                                                     class="space-after"
                                                     data-event="@(d.Http.FileExtension.IsNotBlank() ? "download" : "external")"
                                                     data-size="@(d.Http.FileBytes.IsNotBlank() ? d.Http.FileBytes : "0")"

--- a/Datahub.Web/Pages/Asset.cshtml
+++ b/Datahub.Web/Pages/Asset.cshtml
@@ -130,7 +130,7 @@
                                     <div class="cell small-11">
                                         <div class="highlightable">
                                             <span>
-                                                <a href="@(d.Http.Url)"
+                                                <a href="@AssetHelpers.EnsureHttpsLink((d.Http.Url))"
                                                     class="space-after"
                                                     data-event="@(d.Http.FileExtension.IsNotBlank() ? "download" : "external")"
                                                     data-size="@(d.Http.FileBytes.IsNotBlank() ? d.Http.FileBytes : "0")"

--- a/Datahub.Web/Pages/Helpers/AssetHelpers.cs
+++ b/Datahub.Web/Pages/Helpers/AssetHelpers.cs
@@ -27,6 +27,24 @@ namespace Datahub.Web.Pages.Helpers
                 return String.Empty;
         }
 
+        public static string EnsureHttpsLink(string url)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+            {
+                var b = new UriBuilder(uri)
+                {
+                    Scheme = Uri.UriSchemeHttps,
+                    Port = -1 // default port for scheme
+                };
+
+                return b.ToString();
+            }
+            else
+            {
+                return String.Empty;
+            }
+        }
+
         public static string GetFileExtensionForDisplay(string fileExtension)
         {
             if (fileExtension.IsNotBlank())

--- a/Datahub.Web/Pages/Helpers/AssetHelpers.cs
+++ b/Datahub.Web/Pages/Helpers/AssetHelpers.cs
@@ -27,22 +27,23 @@ namespace Datahub.Web.Pages.Helpers
                 return String.Empty;
         }
 
-        public static string EnsureHttpsLink(string url)
+        public static string EnsureHttpsLinksForDataDotJncc(string url)
         {
             if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
             {
-                var b = new UriBuilder(uri)
+                if (uri.Host == "data.jncc.gov.uk")
                 {
-                    Scheme = Uri.UriSchemeHttps,
-                    Port = -1 // default port for scheme
-                };
+                    var b = new UriBuilder(uri)
+                    {
+                        Scheme = Uri.UriSchemeHttps,
+                        Port = -1 // default port for scheme
+                    };
 
-                return b.ToString();
+                    return b.ToString();
+                }
             }
-            else
-            {
-                return String.Empty;
-            }
+
+            return url;
         }
 
         public static string GetFileExtensionForDisplay(string fileExtension)

--- a/Datahub.Web/Pages/Shared/_SearchResult.cshtml
+++ b/Datahub.Web/Pages/Shared/_SearchResult.cshtml
@@ -23,11 +23,11 @@
 
     @if (Model.Highlights.Any(x => x.Key == "title"))
     {
-        <a href="@(Model.Source.Url)">@Html.Raw(Model.Highlights.First(x => x.Key == "title").Value.Highlights.First())</a>
+        <a href="@AssetHelpers.EnsureHttpsLinksForDataDotJncc(Model.Source.Url))">@Html.Raw(Model.Highlights.First(x => x.Key == "title").Value.Highlights.First())</a>
     }
     else
     {
-        <a href="@(Model.Source.Url)">@(Model.Source.Title)</a>
+        <a href="@AssetHelpers.EnsureHttpsLinksForDataDotJncc((Model.Source.Url))">@(Model.Source.Title)</a>
     }
 
 


### PR DESCRIPTION
This PR should fix the download links by ensuring that any HTTP URL is written as HTTPS in the Asset page resources list. :hear_no_evil: