### PR TITLE
Fixes for datahub PDF indexing 

### DIFF
--- a/Datahub.Ingester/index.js
+++ b/Datahub.Ingester/index.js
@@ -94,9 +94,11 @@ async function publishToHub (message, callback) {
   // Check if messages need base64 content adding and save large messages to S3
   var messageBodies = []
   for (var sqsMessage of sqsMessages) {
+    console.log('Looping through sqsMessages')
     var messageBody = sqsMessage
 
     if (sqsMessageBuilder.fileTypeIsIndexable(sqsMessage.document.file_extension)) {
+      console.log('File is a PDF')
       if (sqsMessage.document.file_base64 === undefined) {
         callback(new Error(`Base64 content not provided for PDF resource for ${sqsMessage.document.title}`))
       }
@@ -105,6 +107,7 @@ async function publishToHub (message, callback) {
       var largeMessage = sizeof(sqsMessage) > maxMessageSize
 
       if (largeMessage) {
+        console.log('Large message, saving to S3')
         var bucket = message.config.sqs.largeMessageBucket
         var { success: uploadSuccess, uploadErrors, s3Key } = await s3MessageUploader.uploadMessageToS3(messageWithBase64Content, message.config)
         if (!uploadSuccess) {

--- a/Datahub.Ingester/index.js
+++ b/Datahub.Ingester/index.js
@@ -109,7 +109,7 @@ async function publishToHub (message, callback) {
       if (largeMessage) {
         console.log('Large message, saving to S3')
         var bucket = message.config.sqs.largeMessageBucket
-        var { success: uploadSuccess, uploadErrors, s3Key } = await s3MessageUploader.uploadMessageToS3(messageWithBase64Content, message.config)
+        var { success: uploadSuccess, uploadErrors, s3Key } = await s3MessageUploader.uploadMessageToS3(sqsMessage, message.config)
         if (!uploadSuccess) {
           callback(new Error(`Failed to upload S3 message with the following errors: [${uploadErrors.join(', ')}]`))
         } else {

--- a/Datahub.Ingester/index.js
+++ b/Datahub.Ingester/index.js
@@ -94,16 +94,13 @@ async function publishToHub (message, callback) {
   // Check if messages need base64 content adding and save large messages to S3
   var messageBodies = []
   for (var sqsMessage of sqsMessages) {
-    console.log('Looping through sqsMessages')
     var messageBody = sqsMessage
 
     if (sqsMessageBuilder.fileTypeIsIndexable(sqsMessage.document.file_extension)) {
-      console.log('File is a PDF')
       if (sqsMessage.document.file_base64 === undefined) {
         callback(new Error(`Base64 content not provided for PDF resource for ${sqsMessage.document.title}`))
       }
 
-      console.log('Large message, saving to S3')
       var bucket = message.config.sqs.largeMessageBucket
       var { success: uploadSuccess, uploadErrors, s3Key } = await s3MessageUploader.uploadMessageToS3(sqsMessage, message.config)
       if (!uploadSuccess) {

--- a/Datahub.Ingester/search/s3MessageUploader.js
+++ b/Datahub.Ingester/search/s3MessageUploader.js
@@ -8,6 +8,7 @@ const s3 = new AWS.S3({
 })
 
 module.exports.uploadMessageToS3 = async function (message, config) {
+  console.log('Attempting to upload message to S3')
   var errors = []
   var s3Key = uuid4()
   var bucket = config.sqs.largeMessageBucket

--- a/Datahub.Ingester/search/s3MessageUploader.js
+++ b/Datahub.Ingester/search/s3MessageUploader.js
@@ -8,7 +8,6 @@ const s3 = new AWS.S3({
 })
 
 module.exports.uploadMessageToS3 = async function (message, config) {
-  console.log('Attempting to upload message to S3')
   var errors = []
   var s3Key = uuid4()
   var bucket = config.sqs.largeMessageBucket


### PR DESCRIPTION
Removing the logic to download files and add base64 content that way as it should already be passed in via Topcat. Also removing the check for large messages as there seems to be an issue with the sizeof function and it's probably neater to upload all PDF messages to S3 first anyway. 